### PR TITLE
Fix incompatibility with other filterbank readers

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -247,14 +247,14 @@ where
         numeric_header_bytes!(foff, self, bytes);
         numeric_header_bytes!(ref_dm, self, bytes);
         numeric_header_bytes!(period, self, bytes);
-        numeric_header_bytes!(nbeams, self, bytes);
-        numeric_header_bytes!(ibeam, self, bytes);
         // Strings
         string_header_bytes!(raw_data_file, self, bytes);
         string_header_bytes!(source_name, self, bytes);
         // Things we need to cast
         cast_header_bytes!(barycentric, self, bytes, u32);
         cast_header_bytes!(pulsarcentric, self, bytes, u32);
+        cast_header_bytes!(nbeams, self, bytes, u32);
+        cast_header_bytes!(ibeam, self, bytes, u32);
         // Bits
         bytes.append(&mut sigproc_string("nbits"));
         bytes.extend_from_slice(&(self.nbits() as u32).to_ne_bytes());

--- a/src/write.rs
+++ b/src/write.rs
@@ -17,7 +17,7 @@ pub struct WriteFilterbank<T> {
     pub telescope_id: Option<u32>,
     pub machine_id: Option<u32>,
     pub data_type: Option<u32>,
-    pub raw_data_file: Option<String>,
+    pub rawdatafile: Option<String>,
     pub source_name: Option<String>,
     pub barycentric: Option<bool>,
     pub pulsarcentric: Option<bool>,
@@ -184,7 +184,7 @@ where
             telescope_id: None,
             machine_id: None,
             data_type: None,
-            raw_data_file: None,
+            rawdatafile: None,
             source_name: None,
             barycentric: None,
             pulsarcentric: None,
@@ -248,7 +248,7 @@ where
         numeric_header_bytes!(ref_dm, self, bytes);
         numeric_header_bytes!(period, self, bytes);
         // Strings
-        string_header_bytes!(raw_data_file, self, bytes);
+        string_header_bytes!(rawdatafile, self, bytes);
         string_header_bytes!(source_name, self, bytes);
         // Things we need to cast
         cast_header_bytes!(barycentric, self, bytes, u32);


### PR DESCRIPTION
* `nbeams` & `ibeam` are defined as `int` in original sigproc code, so maybe a cast is needed.
* `raw_data_file` is called `rawdatafile` in sigproc code, and some other filterbank readers may not recognize it; for simplicity just changed the variable name